### PR TITLE
report every conflicting file only once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: 'Simulate: Count merge conflicts'
 jobs:
   report_via_comment:
     # TODO: Change to `main`
-    uses: appsembler/action-conflict-counter/.github/workflows/report-via-comment.yml@main
+    uses: appsembler/action-conflict-counter/.github/workflows/report-via-comment.yml@unique
     with:
       local_base_branch: 'main'
       upstream_repo: 'https://github.com/edx/edx-platform.git'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: 'Simulate: Count merge conflicts'
 
 jobs:
   report_via_comment:
-    # TODO: Change to `main`
-    uses: appsembler/action-conflict-counter/.github/workflows/report-via-comment.yml@unique
+    uses: appsembler/action-conflict-counter/.github/workflows/report-via-comment.yml@main
     with:
       local_base_branch: 'main'
       upstream_repo: 'https://github.com/edx/edx-platform.git'

--- a/.github/workflows/report-via-comment.yml
+++ b/.github/workflows/report-via-comment.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Merge Conflict counter
         id: conflicts_counter
         # TODO: Change to `main`
-        uses: appsembler/action-conflict-counter@main
+        uses: appsembler/action-conflict-counter@unique
         with:
           local_base_branch: ${{ inputs.local_base_branch }}
           upstream_repo: ${{ inputs.upstream_repo }}

--- a/.github/workflows/report-via-comment.yml
+++ b/.github/workflows/report-via-comment.yml
@@ -35,8 +35,7 @@ jobs:
     steps:
       - name: Merge Conflict counter
         id: conflicts_counter
-        # TODO: Change to `main`
-        uses: appsembler/action-conflict-counter@unique
+        uses: appsembler/action-conflict-counter@main
         with:
           local_base_branch: ${{ inputs.local_base_branch }}
           upstream_repo: ${{ inputs.upstream_repo }}

--- a/conflicts-counter.py
+++ b/conflicts-counter.py
@@ -116,7 +116,7 @@ class ConflictCounter:
             return 0
         else:
             count = check_output([
-                'bash', '-c', 'grep "^=======$" -- $(git ls-files --unmerged | cut -f2) | wc -l'
+                'bash', '-c', 'grep "^=======$" -- $(git ls-files --unmerged | cut -f2 | sort --unique) | wc -l'
             ])
             count = int(count.strip())
         return count
@@ -125,7 +125,7 @@ class ConflictCounter:
         if self.merge_successful:
             files = []
         else:
-            files = check_output(['bash', '-c', 'git ls-files --unmerged | cut -f2 | sort -u'])
+            files = check_output(['bash', '-c', 'git ls-files --unmerged | cut -f2 | sort --unique'])
             files = files.strip().split('\n')
         return files
 


### PR DESCRIPTION
Otherwise conflicts are magnified incorrectly by counting the same file more than once.