### PR TITLE
exclude_paths: option to not count specific paths 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,6 @@ jobs:
       upstream_branch: 'master'
       current_git_repo: 'https://github.com/appsembler/edx-platform.git'
       current_git_branch: 'hawthorn/main'
+      exclude_paths: 'cms/static/js/ conf/locale/ lms/static/js/ package.json'
     secrets:
       github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report-via-comment.yml
+++ b/.github/workflows/report-via-comment.yml
@@ -25,6 +25,11 @@ on:
         type: string
         description: 'Override the github branch for advanced usage.'
         required: false
+      exclude_paths:
+        type: string
+        default: ''
+        description: 'Paths to exclude from counting the conflicts.'
+        required: false
     secrets:
       github_token:
         required: true
@@ -42,6 +47,7 @@ jobs:
           upstream_branch: ${{ inputs.upstream_branch }}
           current_git_repo: ${{ inputs.current_git_repo }}
           current_git_branch: ${{ inputs.current_git_branch }}
+          exclude_paths: ${{ inputs.exclude_paths }}
       - name: Post comment
         uses: actions/github-script@v5
         if: github.event_name == 'pull_request'

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
   current_git_repo:
     description: 'Override the github repo for advanced usage.'
     required: false
+  exclude_paths:
+    description: 'Paths to exclude from counting the conflicts.'
+    required: false
+    default: ''
 
 runs:
   using: 'docker'

--- a/conflicts-counter.py
+++ b/conflicts-counter.py
@@ -4,7 +4,10 @@ import os
 import subprocess
 
 
-def check_output(args, cwd='/repo', **kwargs):
+REPO_PATH = '/repo'
+
+
+def check_output(args, cwd=REPO_PATH, **kwargs):
     return subprocess.check_output(args, cwd=cwd, **kwargs).decode('utf-8')
 
 
@@ -24,11 +27,13 @@ class ConflictReporter:
         current_git_repo = f'{os.environ["GITHUB_SERVER_URL"]}/{os.environ["GITHUB_REPOSITORY"]}.git'
         self.current_git_repo = os.getenv('INPUT_CURRENT_GIT_REPO') or current_git_repo
 
+        self.exclude_paths = os.getenv('INPUT_EXCLUDE_PATHS', '')  # Optional
+
         self.init_git()
 
     def init_git(self):
-        subprocess.check_output(['git', 'clone', self.current_git_repo, '--branch',
-                               self.local_base_branch, '/repo'])
+        subprocess.check_output(['git', 'clone', '--no-tags', self.current_git_repo,
+                                 '--branch', self.local_base_branch, '--no-progress', REPO_PATH])
 
         check_output(['git', 'config', 'user.name', 'GitHub Actions Counter'])
         check_output(['git', 'config', 'user.email', 'dummy@example.com'])
@@ -39,11 +44,11 @@ class ConflictReporter:
         check_output(['git', 'fetch', 'origin', f'{self.current_git_branch}:current_git_branch'])
 
     def report_conflicts(self):
-        base_counter = ConflictCounter('local_base_branch', 'upstream_branch')
+        base_counter = ConflictCounter('local_base_branch', 'upstream_branch', self.exclude_paths)
         base_conflicts = base_counter.count_conflicts()
         base_conflicted_files = set(base_counter.conflicting_files())
 
-        current_counter = ConflictCounter('current_git_branch', 'upstream_branch')
+        current_counter = ConflictCounter('current_git_branch', 'upstream_branch', self.exclude_paths)
         current_conflicts = current_counter.count_conflicts()
         new_conflicted_files = sorted(set(current_counter.conflicting_files()) - base_conflicted_files)
         new_conflicted_files_str = '\n'.join(new_conflicted_files)
@@ -92,9 +97,10 @@ class ConflictCounter:
     This document explains what the git: https://appsembler.atlassian.net/l/c/1fTFXxQ2
     """
 
-    def __init__(self, from_branch, to_branch):
+    def __init__(self, from_branch, to_branch, exclude_paths):
         self.from_branch = from_branch
         self.to_branch = to_branch
+        self.exclude_paths = exclude_paths
         self.merge_successful = False
         self.init_git()
 
@@ -105,11 +111,20 @@ class ConflictCounter:
             self.merge_successful = True
         except subprocess.CalledProcessError:
             status = check_output(['git', 'status'])
+            check_output(['git', 'status'])
             if 'fix conflicts and run "git commit"' in status:
                 self.merge_successful = False
             else:
                 # Something's wrong, we don't know what have happened.
                 raise
+
+        if not self.merge_successful:  # No need to run on successful merge.
+            if self.exclude_paths:
+                # This command won't fail, even if there's an error. Until there's a better way,
+                # that's the quickest method to avoid counting noisy files.
+                _checkout_status = check_output([
+                    'bash', '-c', f'git checkout f{self.from_branch} -- {self.exclude_paths} || true',
+                ])
 
     def count_conflicts(self):
         if self.merge_successful:


### PR DESCRIPTION
1. This option depends on `git checkout --theirs` which is prone to fail.
    To make the implementation simpler the errors in this command errors will be ignored.

    Until there's a better way, that's the quickest method to avoid counting noisy files.

 2. Less verbose git logs

 3. Use constant REPO_PATH