### PR TITLE
fix checkout command bug: remove errornous `f` + refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,6 @@ jobs:
       upstream_branch: 'master'
       current_git_repo: 'https://github.com/appsembler/edx-platform.git'
       current_git_branch: 'hawthorn/main'
-      exclude_paths: 'cms/static/js/ conf/locale/ lms/static/js/ package.json'
+      exclude_paths: 'cms/static/js/,conf/locale/,lms/static/js/,package.json'
     secrets:
       github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report-via-comment.yml
+++ b/.github/workflows/report-via-comment.yml
@@ -28,7 +28,7 @@ on:
       exclude_paths:
         type: string
         default: ''
-        description: 'Paths to exclude from counting the conflicts.'
+        description: 'Comma separated list of paths to exclude from counting the conflicts.'
         required: false
     secrets:
       github_token:

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: 'Override the github repo for advanced usage.'
     required: false
   exclude_paths:
-    description: 'Paths to exclude from counting the conflicts.'
+    description: 'Comma separated list of paths to exclude from counting the conflicts.'
     required: false
     default: ''
 


### PR DESCRIPTION
1) fix typo causing `fatal: invalid reference: fcurrent_git_branch`

```diff
-'bash', '-c', f'git checkout f{self.from_branch}
+'bash', '-c', 'git checkout f{self.from_branch}
```

2) more quiet logs

3) print status and command for debugging

4) split the paths via comma instead of space

5) checkout paths individually

**Review note:** The message is stale since we're stuck with `main` instead of using the PRs branch. #5 shows a better message.