### PR TITLE
fix: github_token is reserved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,4 @@ jobs:
       current_git_branch: 'hawthorn/main'
       exclude_paths: 'cms/static/js/,conf/locale/,lms/static/js/,package.json'
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      custom_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report-via-comment.yml
+++ b/.github/workflows/report-via-comment.yml
@@ -31,7 +31,7 @@ on:
         description: 'Comma separated list of paths to exclude from counting the conflicts.'
         required: false
     secrets:
-      github_token:
+      custom_github_token:
         required: true
 
 jobs:
@@ -49,12 +49,12 @@ jobs:
           current_git_branch: ${{ inputs.current_git_branch }}
           exclude_paths: ${{ inputs.exclude_paths }}
       - name: Post comment
-        uses: actions/github-script@v5
+        uses: actions/github-script@v5.1.0
         if: github.event_name == 'pull_request'
         env:
           CONFLICTS_COUNTER_REPORT: ${{ steps.conflicts_counter.outputs.conflicts_report_json }}
         with:
-          github-token: ${{ secrets.github_token }}
+          github-token: ${{ secrets.custom_github_token }}
           script: |
             const conflictsReport = JSON.parse(process.env.CONFLICTS_COUNTER_REPORT);
             github.rest.issues.createComment({

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
       upstream_repo: 'https://github.com/edx/edx-platform.git'  # Upstream repository that you've forked from
       upstream_branch: 'master'  # Upstream repository's main/master branch name
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      custom_github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 


### PR DESCRIPTION
Renaming `github_token` to `custom_github_token` to avoid syntax error.