### PR TITLE
hide previous comments to reduce github noise 

### DIFF
--- a/.github/workflows/report-via-comment.yml
+++ b/.github/workflows/report-via-comment.yml
@@ -39,6 +39,10 @@ jobs:
     name: report
     runs-on: ubuntu-latest
     steps:
+      - name: Hide old comments
+        uses: appsembler/hide-comment-action@v1
+        with:
+          ends-with: '<!--- action-conflict-counter --->'
       - name: Merge Conflict counter
         id: conflicts_counter
         uses: appsembler/action-conflict-counter@main

--- a/conflicts-counter.py
+++ b/conflicts-counter.py
@@ -17,6 +17,9 @@ def check_output(args, cwd=REPO_PATH, **kwargs):
     return output
 
 
+BOT_SIGNATURE = '<!--- action-conflict-counter --->'
+
+
 class ConflictReporter:
     """
     Reports count and summary of merge conflicts.
@@ -99,6 +102,7 @@ class ConflictReporter:
                 )
 
             reports.append(report)
+            reports.append(BOT_SIGNATURE)
 
         output_json = json.dumps({
             'report': '\n\n'.join(reports),


### PR DESCRIPTION
I think this is the final iteration on this action. It now has all the features we need.

I would be nice to record the number of conflicts on the `edx-platform` repo in DevOps weekly report to track it.

- See: #12

Fixes #12
